### PR TITLE
Update ttbar, readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic -Wextra")
 
 find_package(MoMEMta REQUIRED)
 
-find_package(ROOT REQUIRED)
+find_package(ROOT 6.02 REQUIRED)
 find_library(ROOT_GENVECTOR_LIBRARY GenVector HINTS ${ROOT_LIBRARY_DIR})
 
 set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost REQUIRED log)
+find_package(Boost 1.54 REQUIRED log)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
 include_directories(${MOMEMTA_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Tutorials
 This repository contains a set of working standalone examples illustrating the use of MoMEMta.
 
+## Requirements
+
+- ROOT >= 6.02
+- MoMEMta >= 0.1.0 (and its requirements, such as LHAPDF, Boost)
+- A C++-11 capable compiler
+
 ## Install
 
 - Clone the repository or download and extract the archive.
@@ -13,7 +19,8 @@ make -j 4
 ```
 
 The following options are available when configuring the the build (when running `cmake ..`):
-- `-DMOMEMTA_INCLUDE_DIR=(path)`: Path to your installation of MoMEMta. Use this if your version of MoMEMta was installed locally and not in your system directories
+- `-DMOMEMTA_INCLUDE_DIR=(path)`: Path to the `include` directory of your installation of MoMEMta. Use this if your version of MoMEMta was installed locally and not in your system directories
+- `-DMOMEMTA_LIBRARY=(path)`: Path to the shared library `libmomemta.so` of your installation of MoMEMta. Use this if your version of MoMEMta was installed locally and not in your system directories
 - `-DBOOST_ROOT=(path)`: Use specific Boost library installation
 
 ## Run
@@ -27,7 +34,7 @@ For instance, to build the `TTbar_FullyLeptonic` example's matrix element, do:
 cd ../TTbar_FullyLeptonic/MatrixElement/
 mkdir build
 cd build
-cmake ..
+cmake .. # If you had to specify the `MOMEMTA_INCLUDE_DIR´ when building the tutorials, you'll have to do it here as well
 make -j 4
 ```
 This creates a shared library that can loaded dynamically by MoMEMta. The example can now be executed:

--- a/TTbar_FullyLeptonic/TTbar_FullyLeptonic.lua
+++ b/TTbar_FullyLeptonic/TTbar_FullyLeptonic.lua
@@ -129,6 +129,7 @@ jacobians = {'flatter_s13::jacobian', 'flatter_s134::jacobian', 'flatter_s25::ja
 -- This module defines the `integrands` output, which will be taken by MoMEMta as the value to integrate
 MatrixElement.ttbar = {
   pdf = 'CT10nlo',
+  pdf_scale = parameter('top_mass'),
 
   -- Name of the matrix element, defined in the .cc file of the ME 
   matrix_element = 'TTbar_ee_sm_P1_Sigma_sm_gg_epvebemvexbx',


### PR DESCRIPTION
Update  needed due to some changes in MoMEMta, also update the readme with the requirements. ROOT6 is needed for the tutorials because finding ROOT with cmake for older versions is less easy, and because the .root file included as example does not work well with older versions.
