### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This repository contains a set of working standalone examples illustrating the u
 - MoMEMta >= 0.1.0 (and its requirements, such as LHAPDF, Boost)
 - A C++-11 capable compiler
 
-**Note**: MoMEMta needs to be installed on the system (locally or globally), cf. MoMEMta documentation.
+**Notes**:
+- This is the development branch of the Tutorials, meaning that compatibility with the latest development version of MoMEMta is not guaranteed.
+To ensure the Tutorials work properly, select a branch corresponding to your installed version of MoMEMta.
+- MoMEMta needs to be installed on the system (locally or globally), cf. MoMEMta documentation
 
 ## Install
 


### PR DESCRIPTION
As discussed in @blinkseb's latest PR in MoMEMta, we need a way to be in sync with the different branches of MoMEMta, otherwise the tutorials won't work...

I've pushed a branch called "v0.1" which is guaranteed to work with the v0.1.x version of MoMEMta.

The master branch on the other hand might not always be up-to-date with the master branch of MoMEMta (if non-retrocompatible changes are made there, as is the case with the aforementioned PR).
