### PR TITLE
Update tutorials to reflect latest changes in MoMEMta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic -Wextra")
 # CMake will automagically also link to MoMEMta's dependencies, ie LHAPDF and ROOT
 find_package(MoMEMta CONFIG REQUIRED)
 
-# But MoMEMta doesn't use TreeViewer: we have to add it ourselves
-find_library(ROOT_TREEVIEWER_LIBRARY TreeViewer HINTS ${ROOT_LIBRARY_DIR})
+# But MoMEMta doesn't use TreePlayer: we have to add it ourselves
+find_library(ROOT_TREEPLAYER_LIBRARY TreePlayer HINTS ${ROOT_LIBRARY_DIR} REQUIRED)
 
 # Retrieve all the tutorials & examples
 add_subdirectory(TTbar_FullyLeptonic)

--- a/TTbar_FullyLeptonic/CMakeLists.txt
+++ b/TTbar_FullyLeptonic/CMakeLists.txt
@@ -18,8 +18,8 @@
 add_executable(TTbar_FullyLeptonic "TTbar_FullyLeptonic.cc")
 
 target_link_libraries(TTbar_FullyLeptonic momemta::momemta)
-# The TTbar example uses TreeViewer
-target_link_libraries(TTbar_FullyLeptonic ${ROOT_TREEVIEWER_LIBRARY})
+# The TTbar example uses TreePlayer
+target_link_libraries(TTbar_FullyLeptonic ${ROOT_TREEPLAYER_LIBRARY})
 
 set_target_properties(TTbar_FullyLeptonic PROPERTIES OUTPUT_NAME
       "TTbar_FullyLeptonic.exe")


### PR DESCRIPTION
As the title says, this PR updates the tutorial to the state of art of MoMEMta. I used some "features" that are not yet present but will be available in my next PR (the `Particle` `swap` overload is not available in the current version, as the `export_graph_as` parameter).

Please look at the comments and description I added around the new features, and tell me if you don't understand some stuff or want me to add more explanations.