### PR TITLE
Clarify example tree reading

### DIFF
--- a/TTbar_FullyLeptonic/TTbar_FullyLeptonic.cc
+++ b/TTbar_FullyLeptonic/TTbar_FullyLeptonic.cc
@@ -77,10 +77,9 @@ int main(int argc, char** argv) {
     TTreeReaderValue<int> leading_lep_PID(myReader, "leadLepPID");
 
     /*
-     * Define output TTree, which will be a clone of the input tree,
-     * with the addition of the weights we're computing (including uncertainty and computation time)
+     * Define output TTree, which will contain the weights we're computing (including uncertainty and computation time)
      */
-    std::unique_ptr<TTree> out_tree(chain.CloneTree(0));
+    std::unique_ptr<TTree> out_tree = std::make_unique<TTree>("t", "t");
     double weight_TT, weight_TT_err, weight_TT_time;
     out_tree->Branch("weight_TT", &weight_TT);
     out_tree->Branch("weight_TT_err", &weight_TT_err);
@@ -145,7 +144,7 @@ int main(int argc, char** argv) {
     }
 
     // Save our output TTree
-    out_tree->SaveAs("tt_20evt_weighted.root");
+    out_tree->SaveAs("tt_20evt_weights.root");
 
     return 0;
 }


### PR DESCRIPTION
For the TTbar example, it seemed like the output tree should contain all the original branches from the input. In fact, it doesn't.

It wouldn't be too hard to add it but it's not really the point of these examples and would just clutter them (unless someone disagrees with that).